### PR TITLE
Fix handleMessageSend

### DIFF
--- a/pages/rooms/[roomId].js
+++ b/pages/rooms/[roomId].js
@@ -42,6 +42,10 @@ function RoomPage({ roomsList, currentRoomData, username }) {
 			createNewMsg(undefined, imgKey).then(({ data }) =>
 				setMessages([data.createMessage, ...messages])
 			)
+		} else if (newMessage && imgKey) {
+			createNewMsg(newMessage, imgKey).then(({ data }) =>
+				setMessages([data.createMessage, ...messages])
+			)
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change modifies the `handleMessageSend` function to allow users to send both a text message and an image at the same time. Previously, only a message or only an image could be sent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
